### PR TITLE
Fix Array in Query Bug

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4019,8 +4019,8 @@ public class DefaultCodegen implements CodegenConfig {
 
         final XML referencedSchemaXml = referencedSchema.getXml();
 
-        if(p.getItems() != null){
-            LOGGER.warn("REF: " +  p.getItems().get$ref().toString());
+        if(p.getItems() != null && p.getItems().get$ref() != null){
+            LOGGER.warn("REF: " + p.getItems().get$ref());
         }
 
         if (referencedSchemaXml != null) {


### PR DESCRIPTION
        - name: times
          in: query
          required: false
          schema:
#            type: string
            type: array    #  todo: fix array
            items:
              type: string
              # todo: Error  DefaultCodegen.java  4022
              


Fix null PointerExecption with Arrays in Query 